### PR TITLE
Github action for running test.sh

### DIFF
--- a/.github/workflows/test-sh.yml
+++ b/.github/workflows/test-sh.yml
@@ -1,0 +1,77 @@
+name: Run tests using test.sh
+
+on: [pull_request]
+
+jobs:
+  pytest:
+    name: Python ${{ matrix.os.python }} tests on ${{ matrix.os.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - name: centos
+          version: 7
+          python: 2
+
+        - name: fedora
+          version: 29
+          python: 2
+
+        - name: fedora
+          version: 30
+          python: 3
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - run: ./test.sh
+      env:
+        OS: ${{ matrix.os.name }}
+        OS_VERSION: ${{ matrix.os.version }}
+        PYTHON_VERSION: ${{ matrix.os.python }}
+
+    # - name: Post coverage results to Coveralls.io
+    #   uses: coverallsapp/github-action@v1.0.1
+    #   with:
+    #     github-token: ${{ secrets.github_token }}
+    #     path-to-lcov: ./.coverage
+    #     parallel: true
+
+
+  # coveralls:
+  #   name: Finish parallel job on Coveralls.io
+  #   runs-on: ubuntu-latest
+
+  #   needs: pytest
+
+  #   steps:
+  #   - uses: coverallsapp/github-action@v1.0.1
+  #     with:
+  #       github-token: ${{ secrets.github_token }}
+  #       parallel-finished: true
+
+
+  bandit:
+    name: Bandit analyzer for python ${{ matrix.fedora.python }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        fedora:
+        - version: 29
+          python: 2
+
+        - version: 30
+          python: 3
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - run: ./test.sh
+      env:
+        OS: fedora
+        OS_VERSION: ${{ matrix.fedora.version }}
+        PYTHON_VERSION: ${{ matrix.fedora.python }}
+        ACTION: bandit

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,7 @@ fi
 
 
 CONTAINER_NAME="dockerfile-parse-$OS-$OS_VERSION-py$PYTHON_VERSION"
-RUN="docker exec -ti $CONTAINER_NAME"
+RUN="docker exec -i $CONTAINER_NAME"
 if [[ $OS == "fedora" ]]; then
   PIP_PKG="python$PYTHON_VERSION-pip"
   PIP="pip$PYTHON_VERSION"
@@ -75,7 +75,7 @@ if [[ $PYTHON_VERSION -gt 2 ]]; then $RUN $PIP install -r requirements-py3.txt; 
 
 case ${ACTION} in
 "test")
-  TEST_CMD="py.test --cov dockerfile_parse --cov-report html -vv tests"
+  TEST_CMD="py.test --cov=dockerfile_parse --cov-report=html --color=yes -vv tests"
   ;;
 "bandit")
   $RUN $PKG install -y git-core


### PR DESCRIPTION
Run tests using github actions instead of Travis.

Unfortunately, I was unable to get Coveralls to work:
* The github action requires that the coverage file be in `lcov` format, which pytest seems unable to generate.
* The python `coveralls` package is unreasonably difficult to use outside of Travis. It works for the basic use case of uploading coverage after each test, but getting Coveralls to comment on the PR or merge the results of parallel tests was beyond my abilities.
* See also https://github.com/coverallsapp/github-action/issues/4

By the way, if the github editor tells you that _Matrix options must only contain primitive values_, do not trust it.